### PR TITLE
fix(dsl): emit stage-specific errors

### DIFF
--- a/pkg/dsl/dnsgetaddrinfo.go
+++ b/pkg/dsl/dnsgetaddrinfo.go
@@ -8,6 +8,9 @@ import (
 )
 
 // DNSLookupGetaddrinfo returns a stage that performs DNS lookups using getaddrinfo.
+//
+// This function returns an [ErrDNSLookup] if the error is a DNS lookup error. Remember to
+// use the [IsErrDNSLookup] predicate when setting an experiment test keys.
 func DNSLookupGetaddrinfo() Stage[string, *DNSLookupResult] {
 	return wrapOperation[string, *DNSLookupResult](&dnsLookupGetaddrinfoOperation{})
 }
@@ -75,7 +78,7 @@ func (op *dnsLookupGetaddrinfoOperation) Run(ctx context.Context, rtx Runtime, d
 
 	// handle the error case
 	if err != nil {
-		return nil, err
+		return nil, &ErrDNSLookup{err}
 	}
 
 	// handle the successful case

--- a/pkg/dsl/dnsgetaddrinfo_test.go
+++ b/pkg/dsl/dnsgetaddrinfo_test.go
@@ -1,0 +1,41 @@
+package dsl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-engine/pkg/netemx"
+	"github.com/ooni/probe-engine/pkg/runtimex"
+)
+
+func TestDNSLookupGetaddrinfo(t *testing.T) {
+	t.Run("we correctly wrap DNS lookup errors", func(t *testing.T) {
+		// create the topology
+		topology := runtimex.Try1(netem.NewPPPTopology(
+			"10.0.0.99", "10.0.0.1", log.Log, &netem.LinkConfig{}))
+		defer topology.Close()
+
+		// create DNS server with empty DNS configuration
+		dnsServer := runtimex.Try1(netem.NewDNSServer(
+			log.Log, topology.Server, "10.0.0.1", netem.NewDNSConfig()))
+		defer dnsServer.Close()
+
+		// run function using the client stack
+		netemx.WithCustomTProxy(topology.Client, func() {
+			// create a pipeline that uses getaddrinfo
+			pipeline := DNSLookupGetaddrinfo()
+
+			// lookup using the pipeline
+			input := NewValue("www.example.com")
+			rtx := NewMinimalRuntime(log.Log)
+			results := pipeline.Run(context.Background(), rtx, input)
+
+			// make sure the error is of the correct type
+			if !IsErrDNSLookup(results.Error) {
+				t.Fatal("not a DNS lookup error", results.Error)
+			}
+		})
+	})
+}

--- a/pkg/dsl/dnsgetaddrinfo_test.go
+++ b/pkg/dsl/dnsgetaddrinfo_test.go
@@ -17,7 +17,8 @@ func TestDNSLookupGetaddrinfo(t *testing.T) {
 			"10.0.0.99", "10.0.0.1", log.Log, &netem.LinkConfig{}))
 		defer topology.Close()
 
-		// create DNS server with empty DNS configuration
+		// create DNS server with empty DNS configuration such that a DNS lookup
+		// for any domain will always return NXDOMAIN
 		dnsServer := runtimex.Try1(netem.NewDNSServer(
 			log.Log, topology.Server, "10.0.0.1", netem.NewDNSConfig()))
 		defer dnsServer.Close()

--- a/pkg/dsl/dnsmodel.go
+++ b/pkg/dsl/dnsmodel.go
@@ -1,5 +1,7 @@
 package dsl
 
+import "errors"
+
 // DNSLookupResult is the result of a DNS lookup operation.
 type DNSLookupResult struct {
 	// Domain is the domain we tried to resolve.
@@ -7,4 +9,25 @@ type DNSLookupResult struct {
 
 	// Addresses contains resolved addresses (if any).
 	Addresses []string
+}
+
+// ErrDNSLookup wraps errors occurred during a DNS lookup operation.
+type ErrDNSLookup struct {
+	Err error
+}
+
+// Unwrap supports [errors.Unwrap].
+func (exc *ErrDNSLookup) Unwrap() error {
+	return exc.Err
+}
+
+// Error implements error.
+func (exc *ErrDNSLookup) Error() string {
+	return exc.Err.Error()
+}
+
+// IsErrDNSLookup returns true when an error is an [ErrDNSLookup].
+func IsErrDNSLookup(err error) bool {
+	var exc *ErrDNSLookup
+	return errors.As(err, &exc)
 }

--- a/pkg/dsl/dnsudp.go
+++ b/pkg/dsl/dnsudp.go
@@ -10,6 +10,9 @@ import (
 
 // DNSLookupUDP returns a stage that performs a DNS lookup using the given UDP resolver
 // endpoint; use "ADDRESS:PORT" for IPv4 and "[ADDRESS]:PORT" for IPv6 endpoints.
+//
+// This function returns an [ErrDNSLookup] if the error is a DNS lookup error. Remember to
+// use the [IsErrDNSLookup] predicate when setting an experiment test keys.
 func DNSLookupUDP(endpoint string) Stage[string, *DNSLookupResult] {
 	return wrapOperation[string, *DNSLookupResult](&dnsLookupUDPOperation{endpoint})
 }
@@ -89,7 +92,7 @@ func (sx *dnsLookupUDPOperation) Run(ctx context.Context, rtx Runtime, domain st
 
 	// handle the error case
 	if err != nil {
-		return nil, err
+		return nil, &ErrDNSLookup{err}
 	}
 
 	// handle the successful case

--- a/pkg/dsl/dnsudp_test.go
+++ b/pkg/dsl/dnsudp_test.go
@@ -17,7 +17,8 @@ func TestDNSLookupUDP(t *testing.T) {
 			"10.0.0.99", "10.0.0.1", log.Log, &netem.LinkConfig{}))
 		defer topology.Close()
 
-		// create DNS server with empty DNS configuration
+		// create DNS server with empty DNS configuration such that a DNS lookup
+		// for any domain will always return NXDOMAIN
 		dnsServer := runtimex.Try1(netem.NewDNSServer(
 			log.Log, topology.Server, "10.0.0.1", netem.NewDNSConfig()))
 		defer dnsServer.Close()

--- a/pkg/dsl/dnsudp_test.go
+++ b/pkg/dsl/dnsudp_test.go
@@ -1,0 +1,41 @@
+package dsl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-engine/pkg/netemx"
+	"github.com/ooni/probe-engine/pkg/runtimex"
+)
+
+func TestDNSLookupUDP(t *testing.T) {
+	t.Run("we correctly wrap DNS lookup errors", func(t *testing.T) {
+		// create the topology
+		topology := runtimex.Try1(netem.NewPPPTopology(
+			"10.0.0.99", "10.0.0.1", log.Log, &netem.LinkConfig{}))
+		defer topology.Close()
+
+		// create DNS server with empty DNS configuration
+		dnsServer := runtimex.Try1(netem.NewDNSServer(
+			log.Log, topology.Server, "10.0.0.1", netem.NewDNSConfig()))
+		defer dnsServer.Close()
+
+		// run function using the client stack
+		netemx.WithCustomTProxy(topology.Client, func() {
+			// create an UDP pipeline
+			pipeline := DNSLookupUDP("10.0.0.1:53")
+
+			// lookup using the pipeline
+			input := NewValue("www.example.com")
+			rtx := NewMinimalRuntime(log.Log)
+			results := pipeline.Run(context.Background(), rtx, input)
+
+			// make sure the error is of the correct type
+			if !IsErrDNSLookup(results.Error) {
+				t.Fatal("not an ErrDNSLookup", results.Error)
+			}
+		})
+	})
+}

--- a/pkg/dsl/httpcore.go
+++ b/pkg/dsl/httpcore.go
@@ -14,6 +14,9 @@ import (
 
 // HTTPTransaction returns a stage that uses an HTTP connection to send an HTTP request and
 // reads the response headers as well as a snapshot of the response body.
+//
+// This function returns an [ErrHTTPTransaction] if the error is a DNS lookup error. Remember to
+// use the [IsErrHTTPTransaction] predicate when setting an experiment test keys.
 func HTTPTransaction(options ...HTTPTransactionOption) Stage[*HTTPConnection, *HTTPResponse] {
 	return wrapOperation[*HTTPConnection, *HTTPResponse](&httpTransactionOperation{options})
 }

--- a/pkg/dsl/httpcore.go
+++ b/pkg/dsl/httpcore.go
@@ -113,7 +113,7 @@ func (op *httpTransactionOperation) Run(ctx context.Context, rtx Runtime, conn *
 
 	// handle the case where we failed
 	if err != nil {
-		return nil, err
+		return nil, &ErrHTTPTransaction{err}
 	}
 
 	// prepare the value to return

--- a/pkg/dsl/httpcore.go
+++ b/pkg/dsl/httpcore.go
@@ -15,7 +15,7 @@ import (
 // HTTPTransaction returns a stage that uses an HTTP connection to send an HTTP request and
 // reads the response headers as well as a snapshot of the response body.
 //
-// This function returns an [ErrHTTPTransaction] if the error is a DNS lookup error. Remember to
+// This function returns an [ErrHTTPTransaction] if the error is an HTTP transaction error. Remember to
 // use the [IsErrHTTPTransaction] predicate when setting an experiment test keys.
 func HTTPTransaction(options ...HTTPTransactionOption) Stage[*HTTPConnection, *HTTPResponse] {
 	return wrapOperation[*HTTPConnection, *HTTPResponse](&httpTransactionOperation{options})

--- a/pkg/dsl/httpcore_test.go
+++ b/pkg/dsl/httpcore_test.go
@@ -1,0 +1,88 @@
+package dsl
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/pkg/netxlite/filtering"
+	"github.com/ooni/probe-engine/pkg/runtimex"
+)
+
+func TestHTTPTransaction(t *testing.T) {
+	t.Run("we correctly wrap HTTP transaction errors during the round trip", func(t *testing.T) {
+		// create a server that RSTs during the round trip
+		srvr := filtering.NewHTTPServerCleartext(filtering.HTTPActionReset)
+		defer srvr.Close()
+
+		// create a measurement pipeline
+		pipeline := Compose3(
+			TCPConnect(),
+			HTTPConnectionTCP(),
+			HTTPTransaction(),
+		)
+
+		// create the endpoint
+		endpoint := NewValue(&Endpoint{
+			Address: srvr.URL().Host,
+			Domain:  "www.example.com",
+		})
+
+		// perform the measurement
+		rtx := NewMinimalRuntime(log.Log)
+		results := pipeline.Run(context.Background(), rtx, endpoint)
+
+		// make sure the error was wrapped
+		if !IsErrHTTPTransaction(results.Error) {
+			t.Fatal("not an ErrHTTPTransaction", results.Error)
+		}
+	})
+
+	t.Run("we correctly wrap HTTP transaction errors when reading the body", func(t *testing.T) {
+		// create a server that RSTs after the HTTP round trip
+		srvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// make sure we perform the round trip
+			w.WriteHeader(http.StatusOK)
+
+			// write some body
+			w.Write([]byte("0xabad1deaabad1deaabad1dea"))
+
+			// hijack the underlying connection and send the RST
+			hijacker := w.(http.Hijacker)
+			conn, _ := runtimex.Try2(hijacker.Hijack())
+			tcpConn := conn.(*net.TCPConn)
+			tcpConn.SetLinger(0)
+			tcpConn.Close()
+		}))
+		defer srvr.Close()
+
+		// create a measurement pipeline
+		pipeline := Compose3(
+			TCPConnect(),
+			HTTPConnectionTCP(),
+			HTTPTransaction(),
+		)
+
+		// parse the server URL
+		URL := runtimex.Try1(url.Parse(srvr.URL))
+
+		// create the endpoint
+		endpoint := NewValue(&Endpoint{
+			Address: URL.Host,
+			Domain:  "www.example.com",
+		})
+
+		// perform the measurement
+		rtx := NewMinimalRuntime(log.Log)
+		results := pipeline.Run(context.Background(), rtx, endpoint)
+
+		// make sure the error was wrapped
+		if !IsErrHTTPTransaction(results.Error) {
+			t.Fatal("not an ErrHTTPTransaction", results.Error)
+		}
+	})
+}

--- a/pkg/dsl/httpmodel.go
+++ b/pkg/dsl/httpmodel.go
@@ -1,6 +1,7 @@
 package dsl
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/ooni/probe-engine/pkg/model"
@@ -191,4 +192,25 @@ type HTTPResponse struct {
 
 	// ResponseBodySnapshot is the body snapshot.
 	ResponseBodySnapshot []byte
+}
+
+// ErrHTTPTransaction wraps errors occurred during an HTTP transaction operation.
+type ErrHTTPTransaction struct {
+	Err error
+}
+
+// Unwrap supports [errors.Unwrap].
+func (exc *ErrHTTPTransaction) Unwrap() error {
+	return exc.Err
+}
+
+// Error implements error.
+func (exc *ErrHTTPTransaction) Error() string {
+	return exc.Err.Error()
+}
+
+// IsErrHTTPTransaction returns true when an error is an [ErrHTTPTransaction].
+func IsErrHTTPTransaction(err error) bool {
+	var exc *ErrHTTPTransaction
+	return errors.As(err, &exc)
 }

--- a/pkg/dsl/quichandshake.go
+++ b/pkg/dsl/quichandshake.go
@@ -102,7 +102,7 @@ func (sx *quicHandshakeOperation) Run(ctx context.Context, rtx Runtime, endpoint
 
 	// handle the error case
 	if err != nil {
-		return nil, err
+		return nil, &ErrQUICHandshake{err}
 	}
 
 	// make sure we will close this conn

--- a/pkg/dsl/quichandshake.go
+++ b/pkg/dsl/quichandshake.go
@@ -10,6 +10,9 @@ import (
 )
 
 // QUICHandshake returns a stage that performs a QUIC handshake.
+//
+// This function returns an [ErrQUICHandshake] if the error is a DNS lookup error. Remember to
+// use the [IsErrQUICHandshake] predicate when setting an experiment test keys.
 func QUICHandshake(options ...QUICHandshakeOption) Stage[*Endpoint, *QUICConnection] {
 	return wrapOperation[*Endpoint, *QUICConnection](&quicHandshakeOperation{options})
 }

--- a/pkg/dsl/quichandshake.go
+++ b/pkg/dsl/quichandshake.go
@@ -11,7 +11,7 @@ import (
 
 // QUICHandshake returns a stage that performs a QUIC handshake.
 //
-// This function returns an [ErrQUICHandshake] if the error is a DNS lookup error. Remember to
+// This function returns an [ErrQUICHandshake] if the error is a QUIC handshake error. Remember to
 // use the [IsErrQUICHandshake] predicate when setting an experiment test keys.
 func QUICHandshake(options ...QUICHandshakeOption) Stage[*Endpoint, *QUICConnection] {
 	return wrapOperation[*Endpoint, *QUICConnection](&quicHandshakeOperation{options})

--- a/pkg/dsl/quichandshake_test.go
+++ b/pkg/dsl/quichandshake_test.go
@@ -1,0 +1,43 @@
+package dsl
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/pkg/netxlite"
+	"github.com/ooni/probe-engine/pkg/runtimex"
+)
+
+func TestQUICHandshake(t *testing.T) {
+	t.Run("we correctly wrap QUIC errors", func(t *testing.T) {
+		// create a connection where we're not going to read incoming packets
+		listener := netxlite.NewQUICListener()
+		pconn := runtimex.Try1(listener.Listen(&net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 0, // let the kernel pick a port
+			Zone: "",
+		}))
+		defer pconn.Close()
+		localAddr := pconn.LocalAddr().String()
+
+		// create measurement pipeline
+		pipeline := QUICHandshake()
+
+		// create the endpoint
+		endpoint := NewValue(&Endpoint{
+			Address: localAddr,
+			Domain:  "www.example.com",
+		})
+
+		// perform the measurement
+		rtx := NewMinimalRuntime(log.Log)
+		results := pipeline.Run(context.Background(), rtx, endpoint)
+
+		// make sure the error is correct
+		if !IsErrQUICHandshake(results.Error) {
+			t.Fatal("not an ErrQUICHandshake", results.Error)
+		}
+	})
+}

--- a/pkg/dsl/quicmodel.go
+++ b/pkg/dsl/quicmodel.go
@@ -112,3 +112,24 @@ func QUICHandshakeOptionSNI(value string) QUICHandshakeOption {
 		config.SNI = value
 	}
 }
+
+// ErrQUICHandshake wraps errors occurred during a QUIC handshake operation.
+type ErrQUICHandshake struct {
+	Err error
+}
+
+// Unwrap supports [errors.Unwrap].
+func (exc *ErrQUICHandshake) Unwrap() error {
+	return exc.Err
+}
+
+// Error implements error.
+func (exc *ErrQUICHandshake) Error() string {
+	return exc.Err.Error()
+}
+
+// IsErrQUICHandshake returns true when an error is an [ErrQUICHandshake].
+func IsErrQUICHandshake(err error) bool {
+	var exc *ErrQUICHandshake
+	return errors.As(err, &exc)
+}

--- a/pkg/dsl/tcpconnect.go
+++ b/pkg/dsl/tcpconnect.go
@@ -9,7 +9,7 @@ import (
 
 // TCPConnect returns a stage that performs a TCP connect.
 //
-// This function returns an [ErrTCPConnect] if the error is a DNS lookup error. Remember to
+// This function returns an [ErrTCPConnect] if the error is a TCP connect error. Remember to
 // use the [IsErrTCPConnect] predicate when setting an experiment test keys.
 func TCPConnect() Stage[*Endpoint, *TCPConnection] {
 	return wrapOperation[*Endpoint, *TCPConnection](&tcpConnectOperation{})

--- a/pkg/dsl/tcpconnect.go
+++ b/pkg/dsl/tcpconnect.go
@@ -8,6 +8,9 @@ import (
 )
 
 // TCPConnect returns a stage that performs a TCP connect.
+//
+// This function returns an [ErrTCPConnect] if the error is a DNS lookup error. Remember to
+// use the [IsErrTCPConnect] predicate when setting an experiment test keys.
 func TCPConnect() Stage[*Endpoint, *TCPConnection] {
 	return wrapOperation[*Endpoint, *TCPConnection](&tcpConnectOperation{})
 }

--- a/pkg/dsl/tcpconnect.go
+++ b/pkg/dsl/tcpconnect.go
@@ -76,7 +76,7 @@ func (op *tcpConnectOperation) Run(ctx context.Context, rtx Runtime, endpoint *E
 
 	// handle the error case
 	if err != nil {
-		return nil, err
+		return nil, &ErrTCPConnect{err}
 	}
 
 	// make sure we close the conn when done

--- a/pkg/dsl/tcpconnect_test.go
+++ b/pkg/dsl/tcpconnect_test.go
@@ -1,0 +1,42 @@
+package dsl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-engine/pkg/netemx"
+	"github.com/ooni/probe-engine/pkg/runtimex"
+)
+
+func TestTCPConnect(t *testing.T) {
+	t.Run("we correctly wrap TCP connect errors", func(t *testing.T) {
+		// create the topology
+		topology := runtimex.Try1(netem.NewPPPTopology(
+			"10.0.0.99", "10.0.0.1", log.Log, &netem.LinkConfig{}))
+		defer topology.Close()
+
+		// Note: do not create any TCP listener, so the connection will fail
+
+		// run function using the client stack
+		netemx.WithCustomTProxy(topology.Client, func() {
+			// create a pipeline
+			pipeline := TCPConnect()
+
+			endpoint := NewValue(&Endpoint{
+				Address: "10.0.0.1:80",
+				Domain:  "www.example.com",
+			})
+
+			// lookup using the pipeline
+			rtx := NewMinimalRuntime(log.Log)
+			results := pipeline.Run(context.Background(), rtx, endpoint)
+
+			// make sure the error is of the correct type
+			if !IsErrTCPConnect(results.Error) {
+				t.Fatal("not an ErrTCPConnect", results.Error)
+			}
+		})
+	})
+}

--- a/pkg/dsl/tcpmodel.go
+++ b/pkg/dsl/tcpmodel.go
@@ -1,6 +1,9 @@
 package dsl
 
-import "net"
+import (
+	"errors"
+	"net"
+)
 
 // TCPConnection is the result of performing a TCP connect operation.
 type TCPConnection struct {
@@ -15,4 +18,25 @@ type TCPConnection struct {
 
 	// Trace is the trace we're using.
 	Trace Trace
+}
+
+// ErrTCPConnect wraps errors occurred during a TCP connect operation.
+type ErrTCPConnect struct {
+	Err error
+}
+
+// Unwrap supports [errors.Unwrap].
+func (exc *ErrTCPConnect) Unwrap() error {
+	return exc.Err
+}
+
+// Error implements error.
+func (exc *ErrTCPConnect) Error() string {
+	return exc.Err.Error()
+}
+
+// IsErrTCPConnect returns true when an error is an [ErrTCPConnect].
+func IsErrTCPConnect(err error) bool {
+	var exc *ErrTCPConnect
+	return errors.As(err, &exc)
 }

--- a/pkg/dsl/tlshandshake.go
+++ b/pkg/dsl/tlshandshake.go
@@ -11,7 +11,7 @@ import (
 
 // TLSHandshake returns a stage that performs a TLS handshake.
 //
-// This function returns an [ErrTLSHandshake] if the error is a DNS lookup error. Remember to
+// This function returns an [ErrTLSHandshake] if the error is a TLS handshake error. Remember to
 // use the [IsErrTLSHandshake] predicate when setting an experiment test keys.
 func TLSHandshake(options ...TLSHandshakeOption) Stage[*TCPConnection, *TLSConnection] {
 	return wrapOperation[*TCPConnection, *TLSConnection](&tlsHandshakeOperation{options})

--- a/pkg/dsl/tlshandshake.go
+++ b/pkg/dsl/tlshandshake.go
@@ -95,7 +95,7 @@ func (op *tlsHandshakeOperation) Run(ctx context.Context, rtx Runtime, tcpConn *
 
 	// handle the error case
 	if err != nil {
-		return nil, err
+		return nil, &ErrTLSHandshake{err}
 	}
 
 	// make sure we close this conn

--- a/pkg/dsl/tlshandshake.go
+++ b/pkg/dsl/tlshandshake.go
@@ -10,6 +10,9 @@ import (
 )
 
 // TLSHandshake returns a stage that performs a TLS handshake.
+//
+// This function returns an [ErrTLSHandshake] if the error is a DNS lookup error. Remember to
+// use the [IsErrTLSHandshake] predicate when setting an experiment test keys.
 func TLSHandshake(options ...TLSHandshakeOption) Stage[*TCPConnection, *TLSConnection] {
 	return wrapOperation[*TCPConnection, *TLSConnection](&tlsHandshakeOperation{options})
 }

--- a/pkg/dsl/tlshandshake_test.go
+++ b/pkg/dsl/tlshandshake_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTLSHandshake(t *testing.T) {
-	t.Run("we correctly wrap TLS handshake errors during the handshake", func(t *testing.T) {
+	t.Run("we correctly wrap TLS handshake errors", func(t *testing.T) {
 		// create a server that RSTs during the handshake
 		srvr := filtering.NewTLSServer(filtering.TLSActionReset)
 		defer srvr.Close()

--- a/pkg/dsl/tlshandshake_test.go
+++ b/pkg/dsl/tlshandshake_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTLSHandshake(t *testing.T) {
-	t.Run("we correctly wrap HTTP transaction errors during the round trip", func(t *testing.T) {
+	t.Run("we correctly wrap TLS handshake errors during the handshake", func(t *testing.T) {
 		// create a server that RSTs during the handshake
 		srvr := filtering.NewTLSServer(filtering.TLSActionReset)
 		defer srvr.Close()

--- a/pkg/dsl/tlshandshake_test.go
+++ b/pkg/dsl/tlshandshake_test.go
@@ -1,0 +1,38 @@
+package dsl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/pkg/netxlite/filtering"
+)
+
+func TestTLSHandshake(t *testing.T) {
+	t.Run("we correctly wrap HTTP transaction errors during the round trip", func(t *testing.T) {
+		// create a server that RSTs during the handshake
+		srvr := filtering.NewTLSServer(filtering.TLSActionReset)
+		defer srvr.Close()
+
+		// create a measurement pipeline
+		pipeline := Compose(
+			TCPConnect(),
+			TLSHandshake(),
+		)
+
+		// create the endpoint
+		endpoint := NewValue(&Endpoint{
+			Address: srvr.Endpoint(),
+			Domain:  "www.example.com",
+		})
+
+		// perform the measurement
+		rtx := NewMinimalRuntime(log.Log)
+		results := pipeline.Run(context.Background(), rtx, endpoint)
+
+		// make sure the error was wrapped
+		if !IsErrTLSHandshake(results.Error) {
+			t.Fatal("not an ErrTLSHandshake", results.Error)
+		}
+	})
+}

--- a/pkg/dsl/tlsmodel.go
+++ b/pkg/dsl/tlsmodel.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 
 	"github.com/ooni/probe-engine/pkg/netxlite"
 )
@@ -104,4 +105,25 @@ func TLSHandshakeOptionSNI(value string) TLSHandshakeOption {
 	return func(config *tlsHandshakeConfig) {
 		config.SNI = value
 	}
+}
+
+// ErrTLSHandshake wraps errors occurred during a TLS handshake operation.
+type ErrTLSHandshake struct {
+	Err error
+}
+
+// Unwrap supports [errors.Unwrap].
+func (exc *ErrTLSHandshake) Unwrap() error {
+	return exc.Err
+}
+
+// Error implements error.
+func (exc *ErrTLSHandshake) Error() string {
+	return exc.Err.Error()
+}
+
+// IsErrTLSHandshake returns true when an error is an [ErrTLSHandshake].
+func IsErrTLSHandshake(err error) bool {
+	var exc *ErrTLSHandshake
+	return errors.As(err, &exc)
 }

--- a/pkg/experiment/fbmessenger/dsldnslookup.go
+++ b/pkg/experiment/fbmessenger/dsldnslookup.go
@@ -78,6 +78,11 @@ func (fx *dnsConsistencyCheckFilter) Run(ctx context.Context,
 	rtx dsl.Runtime, input dsl.Maybe[*dsl.DNSLookupResult]) dsl.Maybe[*dsl.DNSLookupResult] {
 	// handle the case where the DNS lookup failed
 	if input.Error != nil {
+		// exclude the case where the error is not caused by a DNS lookup
+		if !dsl.IsErrDNSLookup(input.Error) {
+			return input
+		}
+		// handle a DNS lookup error
 		// TODO(bassosimone): do we need to flip the test keys here?
 		return input
 	}

--- a/pkg/experiment/fbmessenger/dsltcp.go
+++ b/pkg/experiment/fbmessenger/dsltcp.go
@@ -81,6 +81,12 @@ func (fx *tcpReachabilityCheckFilter) Run(ctx context.Context, rtx dsl.Runtime,
 
 	// handle the case where TCP connect failed
 	if input.Error != nil {
+		// make sure the error was indeed caused by TCP connect
+		if !dsl.IsErrTCPConnect(input.Error) {
+			return input
+		}
+
+		// notify the test keys about TCP connect errors
 		fx.tk.onFailedTCPConn(endpointFlag)
 
 		// make sure subsequent steps do not process this error again


### PR DESCRIPTION
This change simplifies writing filters and possibly makes the ErrSkip functionality redundant because now there are predicates for making sure that an error was generated by a specific step.

(I would still like to keep the ErrSkip functionality because it seems tidy to have a way to tell downstream that they should skip running.)

Part of https://github.com/ooni/probe/issues/2494